### PR TITLE
Improve user mission feedback and transition timeout

### DIFF
--- a/posix-configs/SITL/init/rcS_gazebo_standard_vtol
+++ b/posix-configs/SITL/init/rcS_gazebo_standard_vtol
@@ -30,6 +30,7 @@ param set MPC_XY_FF 0.1
 param set MPC_Z_VEL_MAX 1.0
 param set SENS_BOARD_ROT 8
 param set COM_RC_IN_MODE 1
+param set NAV_ACC_RAD 3.0
 rgbledsim start
 tone_alarm start
 gyrosim start

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1719,6 +1719,8 @@ int commander_thread_main(int argc, char *argv[])
 				status.is_rotary_wing = vtol_status.vtol_in_rw_mode;
 				status.in_transition_mode = vtol_status.vtol_in_trans_mode;
 			}
+
+			status_changed = true;
 		}
 
 		/* update global position estimate */

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -805,7 +805,6 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 		break;
 
 	case MAV_CMD_DO_SET_SERVO:
-
 		mission_item->actuator_num = mavlink_mission_item->param1;
 		mission_item->actuator_value = mavlink_mission_item->param2;
 		mission_item->time_inside=0.0f;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -904,9 +904,13 @@ MulticopterPositionControl::cross_sphere_line(const math::Vector<3> &sphere_c, f
 
 void MulticopterPositionControl::control_auto(float dt)
 {
-	if (!_mode_auto) {
+	if (!_mode_auto || _vehicle_status.in_transition_mode || !_vehicle_status.is_rotary_wing) {
 		_mode_auto = true;
 		/* reset position setpoint on AUTO mode activation */
+		if (_vehicle_status.in_transition_mode || !_vehicle_status.is_rotary_wing) {
+			_reset_pos_sp = true;
+			_reset_alt_sp = true;
+		}
 		reset_pos_sp();
 		reset_alt_sp();
 		/* set current velocity as last target velocity to smooth out transition */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -432,7 +432,7 @@ Mission::set_mission_items()
 
 			float takeoff_alt = calculate_takeoff_altitude(&_mission_item);
 
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
+			mavlink_log_info(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
 
 			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
 			_mission_item.lat = _navigator->get_global_position()->lat;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -480,7 +480,7 @@ Mission::set_mission_items()
 
 			new_work_item_type = WORK_ITEM_TYPE_ALIGN;
 
-			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
+			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 			_mission_item.lat = _navigator->get_global_position()->lat;
 			_mission_item.lon = _navigator->get_global_position()->lon;
 			_mission_item.altitude = _navigator->get_global_position()->alt;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -501,6 +501,31 @@ Mission::set_mission_items()
 			new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
 		}
 
+		/* don't advance mission after FW to MC command */
+		if (_mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION
+				&& _work_item_type != WORK_ITEM_TYPE_CMD_BEFORE_MOVE
+				&& !_navigator->get_vstatus()->is_rotary_wing
+				&& !_navigator->get_vstatus()->condition_landed
+				&& pos_sp_triplet->previous.valid) {
+
+			new_work_item_type = WORK_ITEM_TYPE_CMD_BEFORE_MOVE;
+		}
+
+		/* after FW to MC transition finish moving to the waypoint */
+		if (_work_item_type == WORK_ITEM_TYPE_CMD_BEFORE_MOVE
+				&& pos_sp_triplet->previous.valid) {
+
+			new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
+
+			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+			_mission_item.lat = pos_sp_triplet->previous.lat;
+			_mission_item.lon = pos_sp_triplet->previous.lon;
+			_mission_item.altitude = pos_sp_triplet->previous.alt;
+			_mission_item.altitude_is_relative = false;
+			_mission_item.autocontinue = true;
+			_mission_item.time_inside = 0;
+		}
+
 	}
 
 	/*********************************** set setpoints and check next *********************************************/

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -432,7 +432,7 @@ Mission::set_mission_items()
 
 			float takeoff_alt = calculate_takeoff_altitude(&_mission_item);
 
-			mavlink_log_info(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
+			mavlink_log_critical(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
 
 			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
 			_mission_item.lat = _navigator->get_global_position()->lat;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -41,6 +41,7 @@
  * @author Ban Siesta <bansiesta@gmail.com>
  * @author Simon Wilks <simon@uaventure.com>
  * @author Andreas Antener <andreas@uaventure.com>
+ * @author Sander Smeets <sander@droneslab.com>
  */
 
 #include <sys/types.h>

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -694,26 +694,22 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 	dm_item_t dm_item;
 
 	struct mission_s *mission = (onboard) ? &_onboard_mission : &_offboard_mission;
-	int index_to_read = (onboard) ? _current_onboard_mission_index : _current_offboard_mission_index;
+	int current_index = (onboard) ? _current_onboard_mission_index : _current_offboard_mission_index;
+	int index_to_read = current_index + offset;
 
 	/* do not work on empty missions */
 	if (mission->count == 0) {
 		return false;
 	}
 
-	/* move to next item if there is one */
-	if (index_to_read + offset < ((int)mission->count - 1)) {
-		index_to_read += offset;
-	}
-
-	mission_index_ptr = &index_to_read;
-
 	if (onboard) {
 		/* onboard mission */
+		mission_index_ptr = (offset == 0) ? &_current_onboard_mission_index : &index_to_read;
 		dm_item = DM_KEY_WAYPOINTS_ONBOARD;
 
 	} else {
 		/* offboard mission */
+		mission_index_ptr = (offset == 0) ? &_current_offboard_mission_index : &index_to_read;
 		dm_item = DM_KEY_WAYPOINTS_OFFBOARD(_offboard_mission.dataman_id);
 	}
 
@@ -749,7 +745,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 			if (mission_item_tmp.do_jump_current_count < mission_item_tmp.do_jump_repeat_count) {
 
 				/* only raise the repeat count if this is for the current mission item
-				* but not for the next mission item */
+				* but not for the read ahead mission item */
 				if (offset == 0) {
 					(mission_item_tmp.do_jump_current_count)++;
 					/* save repeat count */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -237,6 +237,10 @@ Mission::update_offboard_mission()
 
 	if (orb_copy(ORB_ID(offboard_mission), _navigator->get_offboard_mission_sub(), &_offboard_mission) == OK) {
 		warnx("offboard mission updated: dataman_id=%d, count=%d, current_seq=%d", _offboard_mission.dataman_id, _offboard_mission.count, _offboard_mission.current_seq);
+
+		/* inform the user on succesful storing of mission */
+		mavlink_log_info(_navigator->get_mavlink_fd(), "Mission succesfully stored: %d items", _offboard_mission.count);
+
 		/* determine current index */
 		if (_offboard_mission.current_seq >= 0 && _offboard_mission.current_seq < (int)_offboard_mission.count) {
 			_current_offboard_mission_index = _offboard_mission.current_seq;
@@ -432,7 +436,7 @@ Mission::set_mission_items()
 
 			float takeoff_alt = calculate_takeoff_altitude(&_mission_item);
 
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
+			mavlink_log_info(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
 
 			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
 			_mission_item.lat = _navigator->get_global_position()->lat;
@@ -811,6 +815,11 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 		return false;
 	}
 
+	if(offset==0){
+		/* inform user of waypoint to be executed */
+		mavlink_log_info(_navigator->get_mavlink_fd(), "Executing mission item %i", (int)(current_index+1));
+	}
+
 	if (onboard) {
 		/* onboard mission */
 		mission_index_ptr = (offset == 0) ? &_current_onboard_mission_index : &index_to_read;
@@ -875,7 +884,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 
 			} else {
 				if (offset == 0) {
-					mavlink_log_critical(_navigator->get_mavlink_fd(),
+					mavlink_log_info(_navigator->get_mavlink_fd(),
 							     "DO JUMP repetitions completed");
 				}
 				/* no more DO_JUMPS, therefore just try to continue with next mission item */

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -136,11 +136,14 @@ private:
 
 	float get_absolute_altitude_for_item(struct mission_item_s &mission_item);
 
+	bool prepare_mission_items(bool onboard, struct mission_item_s *mission_item,
+		struct mission_item_s *next_mission_item, bool *has_next_item);
+
 	/**
 	 * Read current or next mission item from the dataman and watch out for DO_JUMPS
 	 * @return true if successful
 	 */
-	bool read_mission_item(bool onboard, bool is_current, struct mission_item_s *mission_item);
+	bool read_mission_item(bool onboard, int offset, struct mission_item_s *mission_item);
 
 	/**
 	 * Save current offboard mission state to dataman
@@ -204,6 +207,15 @@ private:
 	float _on_arrival_yaw; /**< holds the yaw value that should be applied when the current waypoint is reached */
 	float _distance_current_previous; /**< distance from previous to current sp in pos_sp_triplet,
 					    only use if current and previous are valid */
+
+	enum {
+		WORK_ITEM_TYPE_DEFAULT,
+		WORK_ITEM_TYPE_TAKEOFF,
+		WORK_ITEM_TYPE_LAND,
+		WORK_ITEM_TYPE_TRANSITION,
+		WORK_ITEM_TYPE_YAW
+	} _work_item_type;		/**< current type of work to do, intermediate to complete mission item */
+
 };
 
 #endif

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -233,7 +233,8 @@ private:
 		WORK_ITEM_TYPE_DEFAULT,		/**< default mission item */
 		WORK_ITEM_TYPE_TAKEOFF,		/**< takeoff before moving to waypoint */
 		WORK_ITEM_TYPE_MOVE_TO_LAND,	/**< move to land waypoint before descent */
-		WORK_ITEM_TYPE_ALIGN		/**< align for next waypoint */
+		WORK_ITEM_TYPE_ALIGN,		/**< align for next waypoint */
+		WORK_ITEM_TYPE_CMD_BEFORE_MOVE	/**<  */
 	} _work_item_type;	/**< current type of work to do (sub mission item) */
 
 };

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -104,10 +104,10 @@ MissionBlock::is_mission_item_reached()
 		case NAV_CMD_LOITER_UNLIMITED:
 			return false;
 
-		case vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL: /* fallthrough */
-		case vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION:
+		case NAV_CMD_DO_DIGICAM_CONTROL: /* fallthrough */
+		case NAV_CMD_DO_VTOL_TRANSITION:
 			// XXX: we should wait on command ACK or status change instead
-			// currently we just wait so the command be processed
+			// currently we just wait so the command can be processed
 			if (hrt_absolute_time() - _action_start > 1000) {
 				return true;
 
@@ -192,6 +192,7 @@ MissionBlock::is_mission_item_reached()
 
 			/* check yaw if defined only for rotary wing except takeoff */
 			float yaw_err = _wrap_pi(_mission_item.yaw - _navigator->get_global_position()->yaw);
+			PX4_WARN("yaw err: %.3f", (float)yaw_err);
 
 			if (fabsf(yaw_err) < 0.2f) { /* TODO: get rid of magic number */
 				_waypoint_yaw_reached = true;
@@ -258,7 +259,7 @@ MissionBlock::issue_command(const struct mission_item_s *item)
 		return;
 	}
 
-	warnx("forwarding command.\n");
+	warnx("forwarding command %d\n", item->nav_cmd);
 	struct vehicle_command_s cmd = {};
 	mission_item_to_vehicle_command(item, &cmd);
 	_action_start = hrt_absolute_time();
@@ -275,8 +276,8 @@ bool
 MissionBlock::item_contains_position(const struct mission_item_s *item)
 {
 	// XXX: maybe extend that check onto item properties
-	if (item->nav_cmd == vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL ||
-			item->nav_cmd == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
+	if (item->nav_cmd == NAV_CMD_DO_DIGICAM_CONTROL ||
+			item->nav_cmd == NAV_CMD_DO_VTOL_TRANSITION) {
 		return false;
 	}
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -192,7 +192,6 @@ MissionBlock::is_mission_item_reached()
 
 			/* check yaw if defined only for rotary wing except takeoff */
 			float yaw_err = _wrap_pi(_mission_item.yaw - _navigator->get_global_position()->yaw);
-			PX4_WARN("yaw err: %.3f", (float)yaw_err);
 
 			if (fabsf(yaw_err) < 0.2f) { /* TODO: get rid of magic number */
 				_waypoint_yaw_reached = true;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -104,11 +104,18 @@ MissionBlock::is_mission_item_reached()
 		case NAV_CMD_LOITER_UNLIMITED:
 			return false;
 
-		case NAV_CMD_DO_DIGICAM_CONTROL: /* fallthrough */
+		case NAV_CMD_DO_DIGICAM_CONTROL:
+			return true;
+
 		case NAV_CMD_DO_VTOL_TRANSITION:
-			// XXX: we should wait on command ACK or status change instead
-			// currently we just wait so the command can be processed
-			if (hrt_absolute_time() - _action_start > 1000) {
+			/*
+			 * We wait half a second to give the transition command time to propagate.
+			 * As soon as the timeout is over or when we're in transition mode let the mission continue.
+			 */
+			if (hrt_absolute_time() - _action_start > 500000 ||
+					_navigator->get_vstatus()->in_transition_mode) {
+				_action_start = 0;
+
 				return true;
 
 			} else {

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -66,6 +66,7 @@ MissionBlock::MissionBlock(Navigator *navigator, const char *name) :
 	_waypoint_position_reached(false),
 	_waypoint_yaw_reached(false),
 	_time_first_inside_orbit(0),
+	_action_start(0),
 	_actuators{},
 	_actuator_pub(nullptr),
 	_cmd_pub(nullptr)
@@ -81,6 +82,7 @@ MissionBlock::is_mission_item_reached()
 {
 	/* handle non-navigation or indefinite waypoints */
 	switch (_mission_item.nav_cmd) {
+		// XXX: move handling to mission as well
 		case NAV_CMD_DO_SET_SERVO: {
 			memset(&actuators, 0, sizeof(actuators));
 			actuators.control[_mission_item.actuator_num] = 1.0f / 2000 * -_mission_item.actuator_value;
@@ -104,18 +106,13 @@ MissionBlock::is_mission_item_reached()
 
 		case vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL: /* fallthrough */
 		case vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION:
-			{
-			/* forward the command to other processes */
-			warnx("got instantaneous command, forwarding.\n");
-			struct vehicle_command_s cmd = {};
-			cmd.command = _mission_item.nav_cmd;
-			mission_item_to_vehicle_command(&_mission_item, &cmd);
-			if (_cmd_pub != nullptr) {
-				orb_publish(ORB_ID(vehicle_command), _cmd_pub, &cmd);
+			// XXX: we should wait on command ACK or status change instead
+			// currently we just wait so the command be processed
+			if (hrt_absolute_time() - _action_start > 1000) {
+				return true;
+
 			} else {
-				_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &cmd);
-			}
-			return true;
+				return false;
 			}
 
 		default:
@@ -245,6 +242,7 @@ MissionBlock::mission_item_to_vehicle_command(const struct mission_item_s *item,
 	cmd->param5 = item->params[4];
 	cmd->param6 = item->params[5];
 	cmd->param7 = item->params[6];
+	cmd->command = item->nav_cmd;
 
 	cmd->target_system = _navigator->get_vstatus()->system_id;
 	cmd->target_component = _navigator->get_vstatus()->component_id;
@@ -254,8 +252,45 @@ MissionBlock::mission_item_to_vehicle_command(const struct mission_item_s *item,
 }
 
 void
+MissionBlock::issue_command(const struct mission_item_s *item)
+{
+	if (item_contains_position(item)) {
+		return;
+	}
+
+	warnx("forwarding command.\n");
+	struct vehicle_command_s cmd = {};
+	mission_item_to_vehicle_command(item, &cmd);
+	_action_start = hrt_absolute_time();
+
+	if (_cmd_pub != nullptr) {
+		orb_publish(ORB_ID(vehicle_command), _cmd_pub, &cmd);
+
+	} else {
+		_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &cmd);
+	}
+}
+
+bool
+MissionBlock::item_contains_position(const struct mission_item_s *item)
+{
+	// XXX: maybe extend that check onto item properties
+	if (item->nav_cmd == vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL ||
+			item->nav_cmd == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
+		return false;
+	}
+
+	return true;
+}
+
+void
 MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *item, struct position_setpoint_s *sp)
 {
+	/* don't change the setpoint for non-position items */
+	if (!item_contains_position(item)) {
+		return;
+	}
+
 	sp->valid = true;
 	sp->lat = item->lat;
 	sp->lon = item->lon;
@@ -268,7 +303,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	sp->acceptance_radius = item->acceptance_radius;
 
 	switch (item->nav_cmd) {
-	case NAV_CMD_DO_SET_SERVO:
+	case NAV_CMD_DO_SET_SERVO: // XXX: should be also return in the beginning for this?
 			/* Set current position for loitering set point*/
 			sp->lat = _navigator->get_global_position()->lat;
 			sp->lon = _navigator->get_global_position()->lon;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -82,7 +82,7 @@ MissionBlock::is_mission_item_reached()
 {
 	/* handle non-navigation or indefinite waypoints */
 	switch (_mission_item.nav_cmd) {
-		// XXX: move handling to mission as well
+		// XXX: move handling to issue_command() as well
 		case NAV_CMD_DO_SET_SERVO: {
 			memset(&actuators, 0, sizeof(actuators));
 			actuators.control[_mission_item.actuator_num] = 1.0f / 2000 * -_mission_item.actuator_value;
@@ -303,7 +303,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	sp->acceptance_radius = item->acceptance_radius;
 
 	switch (item->nav_cmd) {
-	case NAV_CMD_DO_SET_SERVO: // XXX: should be also return in the beginning for this?
+	case NAV_CMD_DO_SET_SERVO: // XXX: actually also a non position item
 			/* Set current position for loitering set point*/
 			sp->lat = _navigator->get_global_position()->lat;
 			sp->lon = _navigator->get_global_position()->lon;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -78,6 +78,8 @@ protected:
 	 */
 	void reset_mission_item_reached();
 
+	bool item_contains_position(const struct mission_item_s *item);
+
 	/**
 	 * Convert a mission item to a position setpoint
 	 *
@@ -116,10 +118,13 @@ protected:
 	 */
 	void mission_item_to_vehicle_command(const struct mission_item_s *item, struct vehicle_command_s *cmd);
 
+	void issue_command(const struct mission_item_s *item);
+
 	mission_item_s _mission_item;
 	bool _waypoint_position_reached;
 	bool _waypoint_yaw_reached;
 	hrt_abstime _time_first_inside_orbit;
+	hrt_abstime _action_start;
 
 	actuator_controls_s _actuators;
 	orb_advert_t    _actuator_pub;

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -50,7 +50,6 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <uORB/topics/fence.h>
-#include <uORB/topics/vehicle_command.h>
 
 MissionFeasibilityChecker::MissionFeasibilityChecker() :
 	_mavlink_fd(-1),
@@ -235,8 +234,8 @@ bool MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, s
 			missionitem.nav_cmd != NAV_CMD_PATHPLANNING &&
 			missionitem.nav_cmd != NAV_CMD_DO_JUMP &&
 			missionitem.nav_cmd != NAV_CMD_DO_SET_SERVO &&
-			missionitem.nav_cmd != vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL &&
-			missionitem.nav_cmd != vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
+			missionitem.nav_cmd != NAV_CMD_DO_DIGICAM_CONTROL &&
+			missionitem.nav_cmd != NAV_CMD_DO_VTOL_TRANSITION) {
 
 			mavlink_log_critical(_mavlink_fd, "Rejecting mission item %i: unsupported action.", (int)(i+1));
 			return false;

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -64,6 +64,8 @@ enum NAV_CMD {
 	NAV_CMD_DO_JUMP = 177,
 	NAV_CMD_DO_SET_SERVO=183,
 	NAV_CMD_DO_REPEAT_SERVO=184,
+	NAV_CMD_DO_DIGICAM_CONTROL=203,
+	NAV_CMD_DO_VTOL_TRANSITION=3000,
 	NAV_CMD_INVALID=UINT16_MAX /* ensure that casting a large number results in a specific error */
 };
 

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -101,8 +101,8 @@ struct mission_item_s {
 	int do_jump_mission_index;	/**< index where the do jump will go to                 */
 	unsigned do_jump_repeat_count;	/**< how many times do jump needs to be done            */
 	unsigned do_jump_current_count;	/**< count how many times the jump has been done	*/
-	int actuator_num;               /**< actuator number to be set 0..5 ( corresponds to AUX outputs 1..6    */
-	int actuator_value;             /**< new value for selected actuator in ms 900...2000         */
+	int actuator_num;		/**< actuator number to be set 0..5 ( corresponds to AUX outputs 1..6    */
+	int actuator_value;		/**< new value for selected actuator in ms 900...2000         */
 	float params[7];		/**< array to store mission command values for MAV_FRAME_MISSION ***/
 };
 #pragma pack(pop)

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -38,6 +38,7 @@
 *
 * @author Simon Wilks 		<simon@uaventure.com>
 * @author Roman Bapst 		<bapstroman@gmail.com>
+* @author Sander Smeets     <sander@droneslab.com>
 *
 */
 
@@ -69,6 +70,7 @@ private:
 		float pusher_trans;
 		float airspeed_blend;
 		float airspeed_trans;
+		float front_trans_timeout;
 	} _params_standard;
 
 	struct {
@@ -77,6 +79,7 @@ private:
 		param_t pusher_trans;
 		param_t airspeed_blend;
 		param_t airspeed_trans;
+		param_t front_trans_timeout;
 	} _params_handles_standard;
 
 	enum vtol_mode {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -42,6 +42,7 @@
  * @author Lorenz Meier 	<lm@inf.ethz.ch>
  * @author Thomas Gubler	<thomasgubler@gmail.com>
  * @author David Vorsin     <davidvorsin@gmail.com>
+ * @author Sander Smeets    <sander@droneslab.com>
  *
  */
 #include "vtol_att_control_main.h"
@@ -427,8 +428,27 @@ VtolAttitudeControl::is_fixed_wing_requested()
 		to_fw = _transition_command == vehicle_status_s::VEHICLE_VTOL_STATE_FW;
 	}
 
+	if(_abort_transition) {
+		to_fw = false;
+	}
+
 	return to_fw;
 }
+
+/*
+ * Abort transition
+ */
+void
+VtolAttitudeControl::abort_transition()
+{
+	if(!_abort_transition) {
+		// TODO: add mavlink log message
+		_abort_transition = true;
+	}
+
+}
+
+
 
 /**
 * Update parameters.

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -42,6 +42,7 @@
  * @author Lorenz Meier 	<lm@inf.ethz.ch>
  * @author Thomas Gubler	<thomasgubler@gmail.com>
  * @author David Vorsin     <davidvorsin@gmail.com>
+ * @author Sander Smeets    <sander@droneslab.com>
  *
  */
 #ifndef VTOL_ATT_CONTROL_MAIN_H
@@ -106,6 +107,7 @@ public:
 
 	int start();	/* start the task and return OK on success */
 	bool is_fixed_wing_requested();
+	void abort_transition();
 
 	struct vehicle_attitude_s 				*get_att() {return &_v_att;}
 	struct vehicle_attitude_setpoint_s		*get_att_sp() {return &_v_att_sp;}
@@ -201,6 +203,7 @@ private:
 	 * for fixed wings we want to have an idle speed of zero since we do not want
 	 * to waste energy when gliding. */
 	int _transition_command;
+	bool _abort_transition;
 
 	VtolType *_vtol_type;	// base class for different vtol types
 	Tiltrotor *_tiltrotor;	// tailsitter vtol type

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -212,3 +212,14 @@ PARAM_DEFINE_FLOAT(VT_ARSP_TRANS, 10.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_OPT_RECOV_EN, 0);
+
+/**
+ * Timeout front transition
+ *
+ * Time in seconds after which transition will be cancelled
+ *
+ * @min 0.0
+ * @max 20
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_TRANS_TIMEOUT, 10.0f);


### PR DESCRIPTION
This improves mission feedback and implements a transition timeout parameter that cancels transition to FW. Currently only implemented for standard VTOL. The abort procedure can be tested in SITL by setting the  VT_ARSP_TRANS to 20.
