### PR TITLE
Alter cruise speed at any time during a mission.

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -126,6 +126,7 @@ Mission::on_inactive()
 		if (need_to_reset_mission(false)) {
 			reset_offboard_mission(_offboard_mission);
 			update_offboard_mission();
+			_navigator->reset_cruising_speed();
 		}
 
 	} else {
@@ -194,6 +195,7 @@ Mission::on_active()
 	if (need_to_reset_mission(true)) {
 		reset_offboard_mission(_offboard_mission);
 		update_offboard_mission();
+		_navigator->reset_cruising_speed();
 		offboard_updated = true;
 	}
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -229,6 +229,12 @@ Mission::on_active()
 		}
 	}
 
+
+	/* check if a cruise speed change has been commanded */
+	if (_mission_type != MISSION_TYPE_NONE) {
+		cruising_speed_sp_update();
+	}
+
 	/* see if we need to update the current yaw heading */
 	if ((_param_yawmode.get() != MISSION_YAWMODE_NONE
 	     && _param_yawmode.get() < MISSION_YAWMODE_MAX
@@ -984,6 +990,24 @@ void
 Mission::altitude_sp_foh_reset()
 {
 	_min_current_sp_distance_xy = FLT_MAX;
+}
+
+void
+Mission::cruising_speed_sp_update()
+{
+	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+
+	const float cruising_speed = _navigator->get_cruising_speed();
+	
+	/* Don't change setpoint if the current waypoint is not valid */
+	if (!pos_sp_triplet->current.valid || 
+	    fabsf(pos_sp_triplet->current.cruising_speed - cruising_speed) < FLT_EPSILON) {
+		return;
+	}
+
+	pos_sp_triplet->current.cruising_speed = cruising_speed;
+
+	_navigator->set_position_setpoint_triplet_updated();
 }
 
 void

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -165,6 +165,11 @@ private:
 	void altitude_sp_foh_reset();
 
 	/**
+	 * Update the cruising speed setpoint.
+	 */
+	void cruising_speed_sp_update();
+
+	/**
 	 * Abort landing
 	 */
 	void do_abort_landing();
@@ -273,7 +278,6 @@ private:
 		WORK_ITEM_TYPE_TRANSITON_BEFORE_LAND,	/**<  */
 		WORK_ITEM_TYPE_MOVE_TO_LAND_AFTER_TRANSITION	/**<  */
 	} _work_item_type;	/**< current type of work to do (sub mission item) */
-
 };
 
 #endif

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -124,20 +124,7 @@ MissionBlock::is_mission_item_reached()
 			}
 
 		case NAV_CMD_DO_CHANGE_SPEED:
-			// XXX not differentiating ground and airspeed yet
-			if (_mission_item.params[1] > 0.0f) {
-				_navigator->set_cruising_speed(_mission_item.params[1]);
-			} else {
-				_navigator->set_cruising_speed();
-				/* if no speed target was given try to set throttle */
-				if (_mission_item.params[2] > 0.0f) {
-					_navigator->set_cruising_throttle(_mission_item.params[2] / 100);
-				} else {
-					_navigator->set_cruising_throttle();
-				}
-			}
-
-			return true;
+  			return true;
 
 		default:
 			/* do nothing, this is a 3D waypoint */

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -182,8 +182,21 @@ public:
 
 	/**
 	 * Set the cruising speed
-	 */
-	void		set_cruising_speed(float speed=-1.0f) { _mission_cruising_speed = speed; }
+	 *
+ 	 * Passing a negative value or leaving the parameter away will reset the cruising speed
+ 	 * to its default value.
+ 	 *
+ 	 * For VTOL: sets cuising speed for current mode only (multirotor or fixed-wing).
+ 	 *
+  	 */
+	void		set_cruising_speed(float speed=-1.0f);
+
+	/**
+ 	 * Reset cruising speed to default values
+ 	 *
+ 	 * For VTOL: resets both cruising speeds.
+ 	 */ 
+ 	void		reset_cruising_speed();
 
 	/**
 	 * Get the target throttle
@@ -302,7 +315,8 @@ private:
 	control::BlockParamFloat _param_cruising_speed_plane;
 	control::BlockParamFloat _param_cruising_throttle_plane;
 
-	float _mission_cruising_speed;
+	float _mission_cruising_speed_mc;	
+	float _mission_cruising_speed_fw;
 	float _mission_throttle;
 
 	/**

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -684,9 +684,8 @@ Navigator::get_cruising_speed()
 {
 	/* there are three options: The mission-requested cruise speed, or the current hover / plane speed */
 	if (_vstatus.is_rotary_wing) {
-		if (_mission_cruising_speed_mc  > FLT_EPSILON
+		if (_mission_cruising_speed_mc  > 0.0f
 		    && _vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION) {
-
 			return _mission_cruising_speed_mc;
 
 		} else {
@@ -694,7 +693,7 @@ Navigator::get_cruising_speed()
 		}
 
 	} else {
-		if (_mission_cruising_speed_fw > FLT_EPSILON
+		if (_mission_cruising_speed_fw > 0.0f
  		    && _vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION) {
 			return _mission_cruising_speed_fw;
 


### PR DESCRIPTION
Sending the MAV_CMD_DO_CHANGE_SPEED at anytime during a mission will result in the vehicle's current cruise speed being changed to the newly set value immediately. This provides smooth speed control throughout the allowed range for the vehicle type.

@AndreasAntener want to take a look? I can flight test this on multirotor next week. Works nicely on SITL.
